### PR TITLE
Remove -f option in copy mode for compatibility on requeue

### DIFF
--- a/src/main/groovy/fovus/plugin/FovusFileCopyStrategy.groovy
+++ b/src/main/groovy/fovus/plugin/FovusFileCopyStrategy.groovy
@@ -90,7 +90,15 @@ class FovusFileCopyStrategy extends SimpleFileCopyStrategy {
         Path remotePath = executor.getRemotePath(path)
 
         if (stageinMode == "copy") {
-            return super.stageInputFile(remotePath, targetName)
+            def cmd = ''
+            def p = targetName.lastIndexOf('/')
+            if (p > 0) {
+                cmd += "mkdir -p ${Escape.path(targetName.substring(0, p))} && "
+            }
+
+            // Here, we don't use the -f option so data is not overwritten on requeue
+            cmd += "cp -RL ${Escape.path(remotePath.toAbsolutePath().toString())} ${Escape.path(targetName)}"
+            return cmd
         }
         def stageCmd = "fovus_link ${remotePath} ${targetName}"
         return stageCmd


### PR DESCRIPTION
Nextflow by default uses `cp -fRL` for the `copy` mode.
However, on spot requeue, the `-f` option will basically overwrite all files. 
If the file was modified previously, then overwriting it will corrupt the file snapshot, and thus memory restoration will fail. 

This change simply removes the `-f` option for memcheckpoint compatibility