### PR TITLE
Fix edge case with file staging in copy mode for mem checkpoint

### DIFF
--- a/src/main/groovy/fovus/plugin/FovusFileCopyStrategy.groovy
+++ b/src/main/groovy/fovus/plugin/FovusFileCopyStrategy.groovy
@@ -65,8 +65,6 @@ class FovusFileCopyStrategy extends SimpleFileCopyStrategy {
     String getStageInputFilesScript(Map<String, Path> inputFiles) {
         assert inputFiles != null
 
-        def len = inputFiles.size()
-        def delete = []
         def links = []
         for (Map.Entry<String, Path> entry : inputFiles) {
             final stageName = entry.key
@@ -76,8 +74,14 @@ class FovusFileCopyStrategy extends SimpleFileCopyStrategy {
             links << stageInputFile(storePath, stageName)
         }
 
+        if (stageinMode == "copy") {
+            final marker = Escape.path('.fovus-copy-stage-complete')
+            final stagingCmds = links ? links.join(separatorChar) + separatorChar : ''
+            return "if [[ -f ${marker} ]]; then echo \"Skip input staging: marker found ${marker}\"; else ${stagingCmds}touch ${marker}; fi"
+        }
+
         // return a big string containing the command
-        return (delete + links).join(separatorChar)
+        return links.join(separatorChar)
     }
 
     /**
@@ -93,11 +97,10 @@ class FovusFileCopyStrategy extends SimpleFileCopyStrategy {
             def cmd = ''
             def p = targetName.lastIndexOf('/')
             if (p > 0) {
-                cmd += "mkdir -p ${Escape.path(targetName.substring(0, p))} && "
+                cmd += "mkdir -p ${Escape.path(targetName.substring(0, p))}${separatorChar}"
             }
 
-            // Here, we don't use the -f option so data is not overwritten on requeue
-            cmd += "cp -RL ${Escape.path(remotePath.toAbsolutePath().toString())} ${Escape.path(targetName)}"
+            cmd += "cp -fRL ${Escape.path(remotePath.toAbsolutePath().toString())} ${Escape.path(targetName)}"
             return cmd
         }
         def stageCmd = "fovus_link ${remotePath} ${targetName}"

--- a/src/main/groovy/fovus/plugin/FovusFileCopyStrategy.groovy
+++ b/src/main/groovy/fovus/plugin/FovusFileCopyStrategy.groovy
@@ -97,7 +97,7 @@ class FovusFileCopyStrategy extends SimpleFileCopyStrategy {
             def cmd = ''
             def p = targetName.lastIndexOf('/')
             if (p > 0) {
-                cmd += "mkdir -p ${Escape.path(targetName.substring(0, p))}${separatorChar}"
+                cmd += "mkdir -p ${Escape.path(targetName.substring(0, p))} && "
             }
 
             cmd += "cp -fRL ${Escape.path(remotePath.toAbsolutePath().toString())} ${Escape.path(targetName)}"


### PR DESCRIPTION
Even without `-f` option, `cp` still overwrite files in `copy` mode. 

There is also an edge case where we get spot interruption while `cp` is running. This PR adds a marker to ensure no file being unexpectedly overwritten